### PR TITLE
added a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,54 @@
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
 # Compiled class file
 *.class
 
@@ -20,3 +71,12 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# exclude generated Xtend java traces and xtendbins
+*.xtendbin 
+*.java._trace
+
+src-gen/
+xtend-gen/
+target/
+


### PR DESCRIPTION
Some super exciting feature!
if included ignores (unless forced with git add -f <file>):

- artifacts generated by xtext (e.g. src-gen and xtend-gen)
- workspace metadata
- Eclipse launch configurations
- .pydevproject, .cproject
- java class files
- ...